### PR TITLE
Fix deploy to GH pages (static hosting limitation)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,8 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build # Your React build command
-
+      - name: Prepare 404.html for SPA routing
+        run: cp ./build/index.html ./build/404.html
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
 Added a step to copy the index.html to 404.html to use the index.html to be used when a 404 is reached. This is to get around the limitations of GH Pages only serving static pages