### PR TITLE
Fixed infinite spinner when redirecting to Spotify for OAuth

### DIFF
--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -34,7 +34,7 @@ export default function Login({handleIsAuthenticated, setIsLoading}) {
             await initiateOAuthFlow();
         } catch (error) {
             setAuthenticationError(true);
-            console.error("Error fetching access token:", error);
+            console.error("Error initiating OAuth flow:", error);
         }
         
     }

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -29,9 +29,14 @@ export default function Login({handleIsAuthenticated, setIsLoading}) {
     }, [handleIsAuthenticated, setIsLoading])
 
     const handleLogin = async () => {
-        setIsLoading(true); // Potentially show loader before redirect
         setAuthenticationError(false);
-        await initiateOAuthFlow();
+        try {
+            await initiateOAuthFlow();
+        } catch (error) {
+            setAuthenticationError(true);
+            console.error("Error fetching access token:", error);
+        }
+        
     }
 
     return (

--- a/src/services/spotifyService.js
+++ b/src/services/spotifyService.js
@@ -176,7 +176,7 @@ const handleAuthRedirect = async () => {
 		localStorage.setItem('access_token', body.access_token);
 		localStorage.setItem('access_token_expires_at', accessTokenExpiresAt.toString());
 		localStorage.setItem('refresh_token', body.refresh_token); // Only store if present
-		window.history.replaceState({}, document.title, "/jammming");
+		window.history.replaceState({}, document.title, process.env.PUBLIC_URL || "/");
 
 		localStorage.removeItem('code_verifier');
 		

--- a/src/services/spotifyService.js
+++ b/src/services/spotifyService.js
@@ -176,7 +176,7 @@ const handleAuthRedirect = async () => {
 		localStorage.setItem('access_token', body.access_token);
 		localStorage.setItem('access_token_expires_at', accessTokenExpiresAt.toString());
 		localStorage.setItem('refresh_token', body.refresh_token); // Only store if present
-		window.history.replaceState({}, document.title, "/");
+		window.history.replaceState({}, document.title, "/jammming");
 
 		localStorage.removeItem('code_verifier');
 		


### PR DESCRIPTION
-Removed loading indicator when initiating OAuth by redirect, as it caused an infinite loading indicator due to GitHub Pages hosting being static. As the initiating is quite fas,t this should not reduce the user experience greatly